### PR TITLE
🔨 Fix: RichText Editor in lower android version, Update RichTextEditorSampleScreen for supporting empty state icon

### DIFF
--- a/app/src/main/java/com/noblesoftware/portalcorelibrary/MainActivity.kt
+++ b/app/src/main/java/com/noblesoftware/portalcorelibrary/MainActivity.kt
@@ -19,6 +19,7 @@ import com.noblesoftware.portalcorelibrary.sample.CommonSampleScreen
 import com.noblesoftware.portalcorelibrary.sample.ContainerSampleScreen
 import com.noblesoftware.portalcorelibrary.sample.DialogSampleScreen
 import com.noblesoftware.portalcorelibrary.sample.FullEdgeSampleScreen
+import com.noblesoftware.portalcorelibrary.sample.RichTextEditorSampleScreen
 import com.noblesoftware.portalcorelibrary.sample.SnackBarSampleScreen
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -43,6 +44,7 @@ class MainActivity : AppCompatActivity() {
                         composable<ContainerRoute> { ContainerSampleScreen(navHostController = navController) }
                         composable<FullEdgeRoute> { FullEdgeSampleScreen(navHostController = navController) }
                         composable<DialogRoute> { DialogSampleScreen(navHostController = navController) }
+                        composable<RichTextEditorRoute> { RichTextEditorSampleScreen(navHostController = navController) }
                     }
                 }
             }

--- a/app/src/main/java/com/noblesoftware/portalcorelibrary/MainScreen.kt
+++ b/app/src/main/java/com/noblesoftware/portalcorelibrary/MainScreen.kt
@@ -97,6 +97,14 @@ fun MainScreen(
             ) {
                 navHostController.navigate(route = DialogRoute)
             }
+            DefaultSpacer()
+            DefaultButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = "RichText Editor",
+                buttonVariant = ButtonVariant.Neutral
+            ) {
+                navHostController.navigate(route = RichTextEditorRoute)
+            }
         }
     }
 }

--- a/app/src/main/java/com/noblesoftware/portalcorelibrary/Routes.kt
+++ b/app/src/main/java/com/noblesoftware/portalcorelibrary/Routes.kt
@@ -9,3 +9,4 @@ import kotlinx.serialization.Serializable
 @Serializable object ContainerRoute
 @Serializable object FullEdgeRoute
 @Serializable object DialogRoute
+@Serializable object RichTextEditorRoute

--- a/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/RichTextEditorSampleScreen.kt
+++ b/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/RichTextEditorSampleScreen.kt
@@ -1,0 +1,81 @@
+package com.noblesoftware.portalcorelibrary.sample
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
+import androidx.navigation.NavHostController
+import com.noblesoftware.portalcore.R
+import com.noblesoftware.portalcore.component.compose.DefaultSpacer
+import com.noblesoftware.portalcore.component.compose.DefaultTopAppBar
+import com.noblesoftware.portalcore.component.compose.richeditor.RichEditorComposable
+import com.noblesoftware.portalcore.theme.LocalDimen
+import com.noblesoftware.portalcore.util.extension.handleSafeScaffoldPadding
+
+@Composable
+fun RichTextEditorSampleScreen(
+    navHostController: NavHostController
+) {
+    Scaffold(
+        modifier = Modifier.handleSafeScaffoldPadding(),
+        topBar = {
+            DefaultTopAppBar(
+                modifier = Modifier,
+                title = "RichText Editor",
+                canBack = true,
+                navigator = navHostController
+            )
+        },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = colorResource(id = R.color.background_body))
+                .padding(paddingValues = it)
+                .verticalScroll(rememberScrollState())
+                .then(
+                    Modifier.padding(LocalDimen.current.regular)
+                ),
+        ) {
+            Text("Default Editor")
+            RichEditorComposable(
+                modifier = Modifier.fillMaxWidth(),
+                value = "",
+                imageFormName = "image",
+                isImageEnabled = false,
+                isAntiCheatEnable = false,
+                onImageUpload = {},
+                onImageRetrieve = { "" },
+                onSnackbar = {},
+                onTextChanged = {},
+                onTextPaste = {},
+                onTextCopyOrCut = {}
+            )
+            DefaultSpacer()
+            Text("Anticheat enable Editor")
+            RichEditorComposable(
+                modifier = Modifier.fillMaxWidth(),
+                value = "",
+                imageFormName = "image",
+                isImageEnabled = false,
+                isAntiCheatEnable = true,
+                onImageUpload = {},
+                onImageRetrieve = { "" },
+                onSnackbar = {},
+                onTextChanged = {},
+                onTextPaste = {},
+                onTextCopyOrCut = {}
+            )
+        }
+    }
+}

--- a/portalCore/src/main/assets/RichEditor/rich_editor.js
+++ b/portalCore/src/main/assets/RichEditor/rich_editor.js
@@ -427,7 +427,9 @@ RE.editor.addEventListener("copy", function (e) {
     if (RE.isPreventCopyOrCut == "true") {
         var selection = window.getSelection();
 
-        e.clipboardData?.setData('Text', "");
+        if (e.clipboardData) {
+            e.clipboardData.setData('Text', "");
+        }
         e.preventDefault();
 
         // callback copy
@@ -440,7 +442,9 @@ RE.editor.addEventListener("cut", function (e) {
     if (RE.isPreventCopyOrCut == "true") {
         var selection = window.getSelection();
 
-        e.clipboardData?.setData('Text', "");
+        if (e.clipboardData) {
+            e.clipboardData.setData('Text', "");
+        }
         e.preventDefault();
 
         // callback copy

--- a/portalCore/src/main/java/com/noblesoftware/portalcore/component/xml/paginated_bottom_sheet/DefaultPaginatedBottomSheetDialog.kt
+++ b/portalCore/src/main/java/com/noblesoftware/portalcore/component/xml/paginated_bottom_sheet/DefaultPaginatedBottomSheetDialog.kt
@@ -317,12 +317,19 @@ open class DefaultPaginatedBottomSheetDialog : BottomSheetDialogFragment() {
                                         DefaultSpacer(height = LocalDimen.current.extraRegular)
                                         DefaultEmptyState(
                                             modifier = Modifier.fillMaxWidth(),
+                                            icon = if (state.keywords.isBlank() || state.keywords.length < paginatedBottomSheetData.searchQueryMinimalChar)
+                                                paginatedBottomSheetData.initialIcon?.let {
+                                                    painterResource(id = it)
+                                                }
+                                            else paginatedBottomSheetData.icon?.let {
+                                                painterResource(id = it)
+                                            },
                                             title = if (state.keywords.isBlank() || state.keywords.length < paginatedBottomSheetData.searchQueryMinimalChar) paginatedBottomSheetData.initialTitle else paginatedBottomSheetData.title,
                                             message = if (state.keywords.isBlank()) {
                                                 paginatedBottomSheetData.initialSubtitle
                                             } else if (state.keywords.length < paginatedBottomSheetData.searchQueryMinimalChar) {
-                                                paginatedBottomSheetData.subtitle
-                                            } else stringResource(id = R.string.empty_string)
+                                                paginatedBottomSheetData.additionalSubtitle
+                                            } else paginatedBottomSheetData.subtitle
                                         )
                                     }
                                 } else {
@@ -506,7 +513,10 @@ open class DefaultPaginatedBottomSheetDialog : BottomSheetDialogFragment() {
 data class PaginatedBottomSheetData(
     val title: String,
     val subtitle: String,
+    val additionalSubtitle: String,
+    val icon: Int? = null,
     val initialTitle: String,
     val initialSubtitle: String,
+    val initialIcon: Int? = null,
     val searchQueryMinimalChar: Int
 )

--- a/portalCore/src/main/java/com/noblesoftware/portalcore/util/extension/ExtString.kt
+++ b/portalCore/src/main/java/com/noblesoftware/portalcore/util/extension/ExtString.kt
@@ -104,3 +104,20 @@ fun String.htmlToString(): String =
         .replace("\n", " ")
         .replace("\t", "")
         .trim()
+
+fun String.removeSubdomain(): String {
+    val protocolEndIndex = this.indexOf("://")
+
+    if (protocolEndIndex != -1) {
+        val afterProtocol = this.substring(protocolEndIndex + 3) // +3 to skip "://"
+        val firstDotIndex = afterProtocol.indexOf(".")
+
+        if (firstDotIndex != -1) {
+            val beforeDot = afterProtocol.substring(0, firstDotIndex)
+            // Reconstruct the URL: protocol + (part before the removed string) + (part after the removed string)
+            return this.substring(0, protocolEndIndex + 3) + afterProtocol.substring(firstDotIndex)
+        }
+    }
+    // If "://" or a dot after "://" is not found, return the original URL
+    return this
+}


### PR DESCRIPTION
This commit introduces a new sample screen for the RichText Editor component.

- Added `RichTextEditorSampleScreen.kt` to demonstrate the usage of `RichEditorComposable`.
- Updated `Routes.kt` to include `RichTextEditorRoute`.
- Added a button in `MainScreen.kt` to navigate to the RichText Editor sample.
- Registered the new route in `MainActivity.kt`.
- Added a `removeSubdomain` extension function for Strings in `ExtString.kt`.
- Improved null safety in `rich_editor.js` for `e.clipboardData`.
- Enhanced `RichTextEditorSampleScreen.kt` to display different icons and subtitles based on search query state.