### PR TITLE
✨ Add composable property for actions to `RichEditor`, add insertHtmlValue function

### DIFF
--- a/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/RichTextEditorSampleScreen.kt
+++ b/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/RichTextEditorSampleScreen.kt
@@ -2,30 +2,43 @@ package com.noblesoftware.portalcorelibrary.sample
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
 import androidx.navigation.NavHostController
 import com.noblesoftware.portalcore.R
+import com.noblesoftware.portalcore.component.compose.ButtonType
+import com.noblesoftware.portalcore.component.compose.ButtonVariant
+import com.noblesoftware.portalcore.component.compose.DefaultButton
 import com.noblesoftware.portalcore.component.compose.DefaultSpacer
 import com.noblesoftware.portalcore.component.compose.DefaultTopAppBar
 import com.noblesoftware.portalcore.component.compose.richeditor.RichEditorComposable
+import com.noblesoftware.portalcore.component.compose.richeditor.component.DefaultFontBox
+import com.noblesoftware.portalcore.component.xml.dynamic_bottom_sheet.DefaultDynamicBottomSheetDialog
 import com.noblesoftware.portalcore.theme.LocalDimen
 import com.noblesoftware.portalcore.util.extension.handleSafeScaffoldPadding
+import com.noblesoftware.portalcore.util.extension.toHtmlFormatMention
+import com.noblesoftware.portalcorelibrary.MainActivity
 
 @Composable
 fun RichTextEditorSampleScreen(
     navHostController: NavHostController
 ) {
+    val context = LocalContext.current
+    val mention = remember { mutableStateOf("") }
     Scaffold(
         modifier = Modifier.handleSafeScaffoldPadding(),
         topBar = {
@@ -76,6 +89,64 @@ fun RichTextEditorSampleScreen(
                 onTextPaste = {},
                 onTextCopyOrCut = {}
             )
+            DefaultSpacer()
+            Text("Richtext in bottomsheet")
+            DefaultButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = "Open Bottom Sheet",
+                buttonType = ButtonType.Solid,
+                buttonVariant = ButtonVariant.Neutral
+            ) {
+                DefaultDynamicBottomSheetDialog.showDialog(
+                    fragmentManager = (context as MainActivity).supportFragmentManager,
+                    tag = "tag"
+                ) {
+                    RichEditorComposable(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = LocalDimen.current.regular),
+                        value = "",
+                        imageFormName = "image",
+                        isImageEnabled = true,
+                        isAntiCheatEnable = false,
+                        onImageUpload = {},
+                        onImageRetrieve = { "" },
+                        onHtmlRetrieve = { mention.value },
+                        onSnackbar = {},
+                        onTextChanged = {},
+                        onTextPaste = {},
+                        onTextCopyOrCut = {},
+                        action = {
+                            Row {
+                                DefaultFontBox(
+                                    onClick = {
+                                        mention.value =
+                                            "<span style=\"color: #034aa6;\" contenteditable=\"false\"><strong>@${System.currentTimeMillis()}</strong></span>&nbsp;"
+                                    },
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.ic_mention),
+                                        tint = colorResource(id = R.color.text_primary),
+                                        contentDescription = "",
+                                    )
+                                }
+                                DefaultSpacer(width = LocalDimen.current.default)
+                                DefaultFontBox(
+                                    onClick = {
+                                        mention.value = "agus_kurniawan".toHtmlFormatMention()
+                                    },
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.ic_profile),
+                                        tint = colorResource(id = R.color.text_primary),
+                                        contentDescription = "",
+                                    )
+                                }
+                            }
+                        }
+                    )
+                }
+            }
         }
     }
 }

--- a/portalCore/src/main/assets/RichEditor/rich_editor.js
+++ b/portalCore/src/main/assets/RichEditor/rich_editor.js
@@ -271,6 +271,28 @@ RE.insertYoutubeVideoWH = function(url, width, height) {
     RE.insertHTML(html);
 }
 
+RE.insertHtmlValue =  function(htmlString) {
+    RE.restorerange();
+
+    var selection = window.getSelection();
+    if (selection.rangeCount > 0) {
+        var range = selection.getRangeAt(0);
+
+        var tempDiv = document.createElement('div');
+        tempDiv.innerHTML = htmlString;
+
+        while (tempDiv.firstChild) {
+            range.insertNode(tempDiv.firstChild);
+        }
+
+        range.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }
+
+    RE.focus();
+}
+
 RE.insertHTML = function(html) {
     RE.restorerange();
     document.execCommand('insertHTML', false, html);

--- a/portalCore/src/main/java/com/noblesoftware/portalcore/component/compose/richeditor/RichEditorComposable.kt
+++ b/portalCore/src/main/java/com/noblesoftware/portalcore/component/compose/richeditor/RichEditorComposable.kt
@@ -10,12 +10,15 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
@@ -57,6 +60,7 @@ import com.noblesoftware.portalcore.util.extension.findActivity
 import com.noblesoftware.portalcore.util.extension.htmlToString
 import com.noblesoftware.portalcore.util.extension.isFalse
 import com.noblesoftware.portalcore.util.extension.isTrue
+import com.noblesoftware.portalcore.util.extension.loge
 import com.noblesoftware.portalcore.util.extension.orZero
 import com.noblesoftware.portalcore.util.extension.rememberKeyboardState
 import okhttp3.MultipartBody
@@ -84,6 +88,8 @@ fun RichEditorComposable(
     onTextPaste: ((String) -> Unit?) = {},
     onTextCopyOrCut: ((String) -> Unit?) = {},
     onTextChanged: (String) -> Unit,
+    onHtmlRetrieve: (() -> String?)? = null,
+    action: (@Composable LazyItemScope.() -> Unit)? = null
 ) {
 
     val context = LocalContext.current
@@ -115,6 +121,7 @@ fun RichEditorComposable(
             setPlaceholder(placeholder)
             html = value
             setOnTextChangeListener { text ->
+                println("RichEditorComposable text: $text")
                 onTextChanged.invoke(
                     if (text.htmlToString().isBlank()) "" else text
                 )
@@ -188,6 +195,14 @@ fun RichEditorComposable(
         val image = onImageRetrieve.invoke()
         if (image.isNotBlank()) {
             richEditor.insertImageWithSize(image, "", "100%", "auto", false)
+        }
+    }
+
+    LaunchedEffect(onHtmlRetrieve?.invoke()) {
+        val htmlValue = onHtmlRetrieve?.invoke()
+        if (htmlValue.isNullOrBlank().isFalse()) {
+            checkFocusEditor(richEditor)
+            richEditor.insertHtmlValue(htmlValue)
         }
     }
 
@@ -425,6 +440,11 @@ fun RichEditorComposable(
                                 tint = colorResource(id = if (isImageEnabled) R.color.text_primary else R.color.neutral_solid_disabled_color),
                                 contentDescription = "",
                             )
+                        }
+                    }
+                    action?.let {
+                        item {
+                            it()
                         }
                     }
                 }

--- a/portalCore/src/main/java/com/noblesoftware/portalcore/libs/rich_editor/RichEditor.java
+++ b/portalCore/src/main/java/com/noblesoftware/portalcore/libs/rich_editor/RichEditor.java
@@ -445,6 +445,12 @@ public class RichEditor extends WebView {
         exec("javascript:RE.insertImageWithSize('" + url + "', '" + alt + "','" + width + "', '" + height + "', '" + relative.toString() + "');");
     }
 
+    public void insertHtmlValue(String html) {
+        exec("javascript:RE.prepareInsert();");
+        exec("javascript:RE.insertHtmlValue('" + html + "');");
+    }
+
+
     /**
      * the image according to the specific width of the image automatically
      *

--- a/portalCore/src/main/java/com/noblesoftware/portalcore/util/extension/ExtString.kt
+++ b/portalCore/src/main/java/com/noblesoftware/portalcore/util/extension/ExtString.kt
@@ -121,3 +121,7 @@ fun String.removeSubdomain(): String {
     // If "://" or a dot after "://" is not found, return the original URL
     return this
 }
+
+fun String.toHtmlFormatMention(): String {
+    return "<span id=\"#${System.currentTimeMillis()}\" style=\"color: #034aa6;\" contenteditable=\"false\"><strong>@$this</strong></span>&nbsp;"
+}

--- a/portalCore/src/main/res/drawable/ic_mention.xml
+++ b/portalCore/src/main/res/drawable/ic_mention.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M16,8V13C16,13.796 16.316,14.559 16.879,15.121C17.441,15.684 18.204,16 19,16C19.796,16 20.559,15.684 21.121,15.121C21.684,14.559 22,13.796 22,13V12C22,9.747 21.239,7.561 19.841,5.794C18.443,4.028 16.49,2.785 14.297,2.268C12.105,1.75 9.802,1.988 7.762,2.943C5.721,3.897 4.063,5.513 3.056,7.528C2.048,9.543 1.751,11.839 2.211,14.044C2.672,16.249 3.863,18.234 5.593,19.677C7.322,21.121 9.488,21.938 11.74,21.997C13.992,22.055 16.198,21.352 18,20M16,12C16,14.209 14.209,16 12,16C9.791,16 8,14.209 8,12C8,9.791 9.791,8 12,8C14.209,8 16,9.791 16,12Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#7A818B"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
This commit introduces a new mention feature to the rich text editor.

- Added `ic_mention.xml` for the mention icon.
- Implemented `toHtmlFormatMention()` extension function to format mention strings into HTML.
- Added `insertHtmlValue` function in `rich_editor.js` to insert HTML content at the current cursor position.
- Updated `RichEditor.java` to include a corresponding `insertHtmlValue` method.
- Modified `RichEditorComposable.kt` to support inserting HTML values and to include an optional action composable for custom toolbar items.
- Added a sample implementation in `RichTextEditorSampleScreen.kt` demonstrating the mention feature within a bottom sheet.