### PR TITLE
✨ Add parameters isDismissible and isInitialFullscreen [BottomSheetDynamic]

### DIFF
--- a/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/RichTextEditorSampleScreen.kt
+++ b/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/RichTextEditorSampleScreen.kt
@@ -102,8 +102,6 @@ fun RichTextEditorSampleScreen(
                     tag = "tag",
                     buttonFirstEnable = true,
                     buttonSecondEnable = true,
-                    isDismissible = false,
-                    isInitialFullscreen = false,
                     buttonFirstText = R.string.close,
                     buttonSecondText = R.string.okay,
                 ) {

--- a/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/RichTextEditorSampleScreen.kt
+++ b/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/RichTextEditorSampleScreen.kt
@@ -102,6 +102,8 @@ fun RichTextEditorSampleScreen(
                     tag = "tag",
                     buttonFirstEnable = true,
                     buttonSecondEnable = true,
+                    isDismissible = true,
+                    isInitialFullscreen = false,
                     buttonFirstText = R.string.close,
                     buttonSecondText = R.string.okay,
                 ) {

--- a/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/RichTextEditorSampleScreen.kt
+++ b/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/RichTextEditorSampleScreen.kt
@@ -99,11 +99,17 @@ fun RichTextEditorSampleScreen(
             ) {
                 DefaultDynamicBottomSheetDialog.showDialog(
                     fragmentManager = (context as MainActivity).supportFragmentManager,
-                    tag = "tag"
+                    tag = "tag",
+                    buttonFirstEnable = true,
+                    buttonSecondEnable = true,
+                    isDismissible = false,
+                    isInitialFullscreen = false,
+                    buttonFirstText = R.string.close,
+                    buttonSecondText = R.string.okay,
                 ) {
                     RichEditorComposable(
                         modifier = Modifier
-                            .fillMaxWidth()
+                            .fillMaxSize()
                             .padding(horizontal = LocalDimen.current.regular),
                         value = "",
                         imageFormName = "image",

--- a/portalCore/src/main/java/com/noblesoftware/portalcore/component/xml/dynamic_bottom_sheet/DefaultDynamicBottomSheetDialog.kt
+++ b/portalCore/src/main/java/com/noblesoftware/portalcore/component/xml/dynamic_bottom_sheet/DefaultDynamicBottomSheetDialog.kt
@@ -30,6 +30,7 @@ import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.button.MaterialButton
@@ -52,6 +53,9 @@ open class DefaultDynamicBottomSheetDialog : BottomSheetDialogFragment() {
     /** if [isStatusBarTransparent] = true -> set this activity and PortalCoreTheme statusBar to transparent */
     private var isStatusBarTransparent: Boolean = false
 
+    private var initialBottomSheetState = BottomSheetBehavior.STATE_EXPANDED
+    private var dismissible: Boolean = false
+
     private var buttonFirstEnable: Boolean = true
     private var buttonFirstText: Int = R.string.close
     private var buttonFirstType: BottomSheetActionType = BottomSheetActionType.NEUTRAL
@@ -61,6 +65,7 @@ open class DefaultDynamicBottomSheetDialog : BottomSheetDialogFragment() {
     private var buttonSecondText: Int = R.string.okay
     private var buttonSecondType: BottomSheetActionType = BottomSheetActionType.PRIMARY_SOLID
     private var buttonSecondOnClick: () -> Unit = {}
+
     private var onDismiss: () -> Unit = {}
 
     override fun getTheme(): Int = R.style.ModalBottomSheetDialog
@@ -154,8 +159,20 @@ open class DefaultDynamicBottomSheetDialog : BottomSheetDialogFragment() {
                 )
             }
 
+            /** if the initial fullscreen */
+            if (initialBottomSheetState == BottomSheetBehavior.STATE_EXPANDED) {
+                it.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
+                    ?.let {
+                        val bottomSheetBehavior = BottomSheetBehavior.from(it)
+                        bottomSheetBehavior.skipCollapsed = true
+                        bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+                    }
+            }
+            bottomSheetDialog.setCancelable(dismissible)
+
             containerLayout?.addView(buttons)
         }
+
         return bottomSheetDialog
     }
 
@@ -181,6 +198,8 @@ open class DefaultDynamicBottomSheetDialog : BottomSheetDialogFragment() {
         fun showDialog(
             fragmentManager: FragmentManager,
             isStatusBarTransparent: Boolean = false,
+            isDismissible: Boolean = true,
+            isInitialFullscreen: Boolean = false,
             buttonFirstEnable: Boolean = true,
             buttonSecondEnable: Boolean = false,
             @StringRes buttonFirstText: Int = R.string.close,
@@ -195,6 +214,9 @@ open class DefaultDynamicBottomSheetDialog : BottomSheetDialogFragment() {
         ) {
             DefaultDynamicBottomSheetDialog().apply {
                 this.isStatusBarTransparent = isStatusBarTransparent
+                this.dismissible = isDismissible
+                this.initialBottomSheetState =
+                    if (isInitialFullscreen) BottomSheetBehavior.STATE_EXPANDED else BottomSheetBehavior.STATE_HALF_EXPANDED
                 this.buttonFirstEnable = buttonFirstEnable
                 this.buttonSecondEnable = buttonSecondEnable
                 this.buttonFirstText = buttonFirstText


### PR DESCRIPTION
✨ Add parameters isDismissible and isInitialFullscreen

This commit introduces two new parameters, `isDismissible` and `isInitialFullscreen`, to the `DefaultDynamicBottomSheetDialog`.

- `isDismissible`: Controls whether the dialog can be dismissed by tapping outside or pressing the back button.
- `isInitialFullscreen`: Determines if the bottom sheet should initially occupy the entire screen.

The `RichTextEditorSampleScreen` has been updated to utilize these new parameters, setting `isDismissible` to `false` and `isInitialFullscreen` to `false`. Additionally, the `RichEditorComposable` within the sample now fills the maximum available size.