### PR TITLE
:sparkles: Add Leading Icon & Count to DefaultTextInput

### DIFF
--- a/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/CommonSampleScreen.kt
+++ b/app/src/main/java/com/noblesoftware/portalcorelibrary/sample/CommonSampleScreen.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -28,11 +30,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.noblesoftware.portalcore.R
 import com.noblesoftware.portalcore.component.compose.BottomSheetType
@@ -84,9 +88,16 @@ fun CommonSampleScreen(
     val segmentedButtonList = remember {
         mutableStateOf(
             listOf(
-                SelectOption(id = 1, name = "Semester 1", isSelected = true),  // set the `isSelected` if you want to set default selected
+                SelectOption(
+                    id = 1,
+                    name = "Semester 1",
+                    isSelected = true
+                ),  // set the `isSelected` if you want to set default selected
                 SelectOption(id = 2, name = "Semester 2"),
-                SelectOption(id = 3, nameId = R.string.medium) // in case if you want to using @StringRes
+                SelectOption(
+                    id = 3,
+                    nameId = R.string.medium
+                ) // in case if you want to using @StringRes
             )
         )
     }
@@ -736,6 +747,34 @@ fun CommonSampleScreen(
                     Text(text = "input default")
                     DefaultSpacer()
 
+                    DefaultTextInputDropdown(
+                        label = "Label",
+                        placeholder = "Please select label",
+                        required = true,
+                        leadingIcon = {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxHeight()
+                                    .padding(
+                                        start = LocalDimen.current.medium,
+                                        end = LocalDimen.current.default
+                                    ),
+                                verticalArrangement = Arrangement.Center
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(20.dp)
+                                        .clip(CircleShape)
+                                        .background(colorResource(R.color.neutral_solid_disabled_color))
+                                )
+                            }
+                        },
+                        value = text.value,
+                        onClick = {
+
+                        },
+                        onValueChange = { text.value = it })
+                    DefaultSpacer()
                     DefaultTextInput(
                         label = "Email",
                         placeholder = "Please input email",
@@ -757,8 +796,10 @@ fun CommonSampleScreen(
                         placeholder = "Please input address",
                         required = true,
                         singleLine = false,
+                        isCount = true,
                         value = text.value,
                         minLines = 4,
+                        maxLength = 10,
                         onValueChange = { text.value = it })
                     DefaultSpacer()
 

--- a/portalCore/src/main/java/com/noblesoftware/portalcore/component/compose/DefaultTextInput.kt
+++ b/portalCore/src/main/java/com/noblesoftware/portalcore/component/compose/DefaultTextInput.kt
@@ -7,10 +7,12 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -56,6 +58,7 @@ import com.noblesoftware.portalcore.R
 import com.noblesoftware.portalcore.theme.LocalDimen
 import com.noblesoftware.portalcore.theme.LocalShapes
 import com.noblesoftware.portalcore.util.extension.isFalse
+import com.noblesoftware.portalcore.util.extension.isTrue
 
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
@@ -116,6 +119,7 @@ fun DefaultTextInput(
     inputType: KeyboardType = KeyboardType.Text,
     readOnly: Boolean = false,
     singleLine: Boolean = true,
+    isCount: Boolean = false,
     maxLength: Int = Int.MAX_VALUE,
     maxLines: Int = 1,
     minLines: Int = 1,
@@ -395,6 +399,28 @@ fun DefaultTextInput(
                     modifier = Modifier.padding(start = 5.dp, top = 1.dp),
                     text = helperText,
                     color = colorResource(id = R.color.text_secondary),
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        colorResource(id = R.color.text_primary),
+                    )
+                )
+            }
+        }
+        AnimatedVisibility(
+            visible = isCount.isTrue(),
+            enter = slideInVertically() + fadeIn(),
+            exit = slideOutVertically() + fadeOut()
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 5.dp)
+                    .align(alignment = Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.End
+            ) {
+                Text(
+                    modifier = Modifier.padding(end = 5.dp, top = 1.dp),
+                    text = "${value.length}/$maxLength",
+                    color = colorResource(id = R.color.text_icon),
                     style = MaterialTheme.typography.bodySmall.copy(
                         colorResource(id = R.color.text_primary),
                     )

--- a/portalCore/src/main/java/com/noblesoftware/portalcore/component/compose/DefaultTextInputDropdown.kt
+++ b/portalCore/src/main/java/com/noblesoftware/portalcore/component/compose/DefaultTextInputDropdown.kt
@@ -49,6 +49,7 @@ fun DefaultTextInputDropdown(
     enabled: Boolean = true,
     required: Boolean = false,
     errorText: String = stringResource(id = R.string.empty_string),
+    leadingIcon: @Composable (() -> Unit)? = null,
     @DrawableRes icon: Int = R.drawable.ic_expand_more_filled,
     @ColorRes iconTint: Int = R.color.text_icon,
     onClick: () -> Unit,
@@ -68,6 +69,7 @@ fun DefaultTextInputDropdown(
             value = value,
             placeholder = placeholder,
             inputType = KeyboardType.Text,
+            leadingIcon = leadingIcon,
             trailingIcon = {
                 DefaultTextInputIcon(
                     modifier = Modifier


### PR DESCRIPTION
✨ Add Leading Icon & Count to DefaultTextInput

This commit introduces several enhancements to the `DefaultTextInput` and `DefaultTextInputDropdown` composables, along with updates to the sample screen:

- **`DefaultTextInputDropdown`**:
    - Added an optional `leadingIcon` parameter to allow displaying an icon at the start of the dropdown.

- **`DefaultTextInput`**:
    - Introduced an `isCount` boolean parameter. When true, it displays a character count (e.g., "0/250") below the input field.
    - The character count is dynamically updated as the user types.

- **`CommonSampleScreen`**:
    - Added a new example demonstrating the `DefaultTextInputDropdown` with a custom `leadingIcon` (a circular colored box).
    - Updated an existing `DefaultTextInput` example for "Address" to:
        - Enable `isCount`.
        - Set a `maxLength` of 10.